### PR TITLE
Push to Zapier on git tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,23 @@
+name: Deploy
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+      - run: npm install -g zapier-platform-cli
+      - run: |
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git config user.name "$GITHUB_ACTOR"
+          npm install
+          npm version $(git describe --tags --abbrev=0)
+          zapier push
+        env:
+          CI: true
+          ZAPIER_DEPLOY_KEY: ${{ secrets.ZAPIER_DEPLOY_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 node_modules
-build/build.zip
+build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "habitica",
-  "version": "2.2.1",
+  "version": "0.0.0",
   "description": "Habitica is a free habit building and productivity app that treats real life like a game. With in-game rewards and punishments to motivate you and a strong social network to inspire you, Habitica can help you achieve your goals to become healthy, hard-working, and happy.",
   "repository": "HabitRPG/habitica-zapier",
   "homepage": "https://habitica.com/",


### PR DESCRIPTION
Continuous delivery for habitica-zapier . Can be triggered from Github UI by simply creating a release. 

After merging this you need to set `ZAPIER_DEPLOY_KEY` in the Project Secrets with value of deployKey in your local .zapierrc.  i.e if .zapierrc content is 
```js
{
  "deployKey": "xyz"
}
```
 the value of the secret is xyz. Adding a secret is documented [here](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#creating-encrypted-secrets) 